### PR TITLE
Move the execution of db queries out of the contextmanager 

### DIFF
--- a/wikilabels/database/campaigns.py
+++ b/wikilabels/database/campaigns.py
@@ -6,214 +6,193 @@ class Campaigns(Collection):
 
     def create(self, wiki, name, form, view, labels_per_task,
                tasks_per_assignment, active, info_url):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                INSERT INTO campaign
-                (name, wiki, form, view, labels_per_task,
-                 tasks_per_assignment, active, info_url, created)
-                VALUES (%(name)s, %(wiki)s, %(form)s, %(view)s,
-                        %(labels_per_task)s, %(tasks_per_assignment)s,
-                        %(active)s, %(info_url)s, NOW()) RETURNING *
-            """, {'wiki': wiki,
-                  'name': name,
-                  'form': form,
-                  'view': view,
-                  'info_url': info_url,
-                  'labels_per_task': labels_per_task,
-                  'tasks_per_assignment': tasks_per_assignment,
-                  'active': active})
+        cursor = self.db.execute("""
+            INSERT INTO campaign
+            (name, wiki, form, view, labels_per_task,
+            tasks_per_assignment, active, info_url, created)
+            VALUES (%(name)s, %(wiki)s, %(form)s, %(view)s,
+                  %(labels_per_task)s, %(tasks_per_assignment)s,
+                  %(active)s, %(info_url)s, NOW()) RETURNING *
+        """, {'wiki': wiki,
+              'name': name,
+              'form': form,
+              'view': view,
+              'info_url': info_url,
+              'labels_per_task': labels_per_task,
+              'tasks_per_assignment': tasks_per_assignment,
+              'active': active})
 
-            row = next(cursor)
-            return row
+        row = next(cursor)
+        return row
 
     def wiki_name_exists(self, wiki, name):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT 1
-                FROM campaign
-                WHERE wiki = %(wiki)s AND name = %(name)s;
-            """, {'wiki': wiki, 'name': name})
+        cursor = self.db.execute("""
+            SELECT 1
+            FROM campaign
+            WHERE wiki = %(wiki)s AND name = %(name)s;
+        """, {'wiki': wiki, 'name': name})
 
-            try:
-                _ = next(cursor)
-                return True or _
-            except StopIteration:
-                return False
+        try:
+            _ = next(cursor)
+            return True or _
+        except StopIteration:
+            return False
 
     def get(self, campaign_id, stats=False):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT
-                    campaign.id,
-                    campaign.name,
-                    campaign.form,
-                    campaign.view,
-                    campaign.wiki,
-                    EXTRACT(EPOCH FROM campaign.created) AS created,
-                    labels_per_task,
-                    tasks_per_assignment,
-                    active,
-                    campaign.info_url
-                FROM campaign
-                WHERE id = %(campaign_id)s;
-            """, {'campaign_id': campaign_id})
-
-            try:
-                row = next(cursor)
-                if stats:
-                    row['stats'] = self.stats_for(campaign_id)
-                return row
-            except StopIteration:
-                raise NotFoundError("campaign_id={0}".format(campaign_id))
+        cursor = self.db.execute("""
+            SELECT
+                campaign.id,
+                campaign.name,
+                campaign.form,
+                campaign.view,
+                campaign.wiki,
+                EXTRACT(EPOCH FROM campaign.created) AS created,
+                labels_per_task,
+                tasks_per_assignment,
+                active,
+                campaign.info_url
+            FROM campaign
+            WHERE id = %(campaign_id)s;
+        """, {'campaign_id': campaign_id})
+        try:
+            row = next(cursor)
+            if stats:
+                row['stats'] = self.stats_for(campaign_id)
+            return row
+        except StopIteration:
+            raise NotFoundError("campaign_id={0}".format(campaign_id))
 
     def stats_for(self, campaign_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT
-                    COUNT(DISTINCT task.id) AS tasks,
-                    SUM(label.task_id IS NOT NULL::int) AS labels,
-                    COUNT(DISTINCT label.user_id) AS coders,
-                    (SELECT COUNT(*)
-                     FROM workset_task
-                     INNER JOIN task ON workset_task.task_id = task.id
-                     WHERE task.campaign_id = %(campaign_id)s)
-                    AS assignments
-                FROM task
-                LEFT JOIN label ON label.task_id = task.id
-                WHERE task.campaign_id = %(campaign_id)s;
-            """, {'campaign_id': campaign_id})
+        cursor = self.db.execute("""
+              SELECT
+                  COUNT(DISTINCT task.id) AS tasks,
+                  SUM(label.task_id IS NOT NULL::int) AS labels,
+                  COUNT(DISTINCT label.user_id) AS coders,
+                  (SELECT COUNT(*)
+                    FROM workset_task
+                    INNER JOIN task ON workset_task.task_id = task.id
+                    WHERE task.campaign_id = %(campaign_id)s)
+                  AS assignments
+              FROM task
+              LEFT JOIN label ON label.task_id = task.id
+              WHERE task.campaign_id = %(campaign_id)s;
+        """, {'campaign_id': campaign_id})
 
-            return next(cursor)
+        return next(cursor)
 
     def has_open_tasks(self, campaign_id, user_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            # Check if there are tasks to assign that haven't already been
-            # labeled by this user.
-            cursor.execute("""
-                SELECT
-                  task.id
-                FROM campaign
-                INNER JOIN task ON task.campaign_id = campaign.id
-                LEFT JOIN label ON label.task_id = task.id
-                WHERE campaign.id = %(campaign_id)s
-                GROUP BY task.id, campaign.labels_per_task
-                HAVING
-                  COUNT(label.task_id) < campaign.labels_per_task AND
+        # Check if there are tasks to assign that haven't already been
+        # labeled by this user.
+        cursor = self.db.execute("""
+            SELECT
+                task.id
+            FROM campaign
+            INNER JOIN task ON task.campaign_id = campaign.id
+            LEFT JOIN label ON label.task_id = task.id
+            WHERE campaign.id = %(campaign_id)s
+            GROUP BY task.id, campaign.labels_per_task
+            HAVING
+                 COUNT(label.task_id) < campaign.labels_per_task AND
                   SUM((label.user_id IS NOT NULL AND
                        label.user_id = %(user_id)s)::int) = 0
                 LIMIT 1
-            """, {'campaign_id': campaign_id,
-                  'user_id': user_id})
+        """, {'campaign_id': campaign_id,
+              'user_id': user_id})
 
-            rows = cursor.fetchall()
-            return len(rows) > 0
+        rows = cursor.fetchall()
+        return len(rows) > 0
 
     def for_wiki(self, wiki, stats=False, all_=False):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            query = """
-                SELECT
-                    campaign.id,
-                    campaign.name,
-                    campaign.form,
-                    campaign.view,
-                    campaign.wiki,
-                    EXTRACT(EPOCH FROM campaign.created) AS created,
-                    labels_per_task,
-                    tasks_per_assignment,
-                    active,
-                    campaign.info_url
-                FROM campaign
-                WHERE
-                    wiki = %(wiki)s
-            """
-            if not all_:
-                query += "AND active"
+        query = """
+            SELECT
+                campaign.id,
+                campaign.name,
+                campaign.form,
+                campaign.view,
+                campaign.wiki,
+                EXTRACT(EPOCH FROM campaign.created) AS created,
+                labels_per_task,
+                tasks_per_assignment,
+                active,
+                campaign.info_url
+            FROM campaign
+            WHERE
+                wiki = %(wiki)s
+        """
+        if not all_:
+            query += "AND active"
 
-            cursor.execute(query, {'wiki': wiki})
-            rows = []
-            for row in cursor:
-                if stats:
-                    row['stats'] = self.stats_for(row['id'])
-                rows.append(row)
+        cursor = self.db.execute(query, {'wiki': wiki})
+        rows = []
+        for row in cursor:
+            if stats:
+                row['stats'] = self.stats_for(row['id'])
+            rows.append(row)
 
-            return rows
+        return rows
 
     def for_user(self, user_id, stats=False):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT DISTINCT
-                    campaign.id,
-                    campaign.name,
-                    campaign.form,
-                    campaign.view,
-                    campaign.wiki,
-                    EXTRACT(EPOCH FROM campaign.created) AS created,
-                    labels_per_task,
-                    tasks_per_assignment,
-                    active,
-                    campaign.info_url
-                FROM workset
-                INNER JOIN campaign ON campaign_id = campaign.id
-                WHERE user_id = %(user_id)s
-                ORDER BY campaign.id
-            """, {'user_id': user_id})
+        cursor = self.db.execute("""
+            SELECT DISTINCT
+                campaign.id,
+                campaign.name,
+                campaign.form,
+                campaign.view,
+                campaign.wiki,
+                EXTRACT(EPOCH FROM campaign.created) AS created,
+                labels_per_task,
+                tasks_per_assignment,
+                active,
+                campaign.info_url
+            FROM workset
+            INNER JOIN campaign ON campaign_id = campaign.id
+            WHERE user_id = %(user_id)s
+            ORDER BY campaign.id
+        """, {'user_id': user_id})
 
-            rows = []
-            for row in cursor:
-                if stats:
-                    row['stats'] = self.stats_for(row['id'])
-                rows.append(row)
+        rows = []
+        for row in cursor:
+            if stats:
+                row['stats'] = self.stats_for(row['id'])
+            rows.append(row)
 
-            return rows
+        return rows
 
     def wikis(self):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT DISTINCT wiki
-                FROM campaign
-                WHERE active
-                ORDER BY wiki
-            """)
+        cursor = self.db.execute("""
+            SELECT DISTINCT wiki
+            FROM campaign
+            WHERE active
+            ORDER BY wiki
+        """)
 
-            return [row['wiki'] for row in cursor]
+        return [row['wiki'] for row in cursor]
 
     def users(self, campaign_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT label.user_id AS user, COUNT(*) AS count
-                FROM label
-                JOIN workset_task ON label.task_id = workset_task.task_id
-                JOIN workset ON workset.id = workset_task.workset_id
-                WHERE workset.campaign_id = {0}
-                GROUP BY label.user_id
-                ORDER BY COUNT(*) DESC;
-            """.format(int(campaign_id)))
+        cursor = self.db.execute("""
+            SELECT label.user_id AS user, COUNT(*) AS count
+            FROM label
+            JOIN workset_task ON label.task_id = workset_task.task_id
+            JOIN workset ON workset.id = workset_task.workset_id
+            WHERE workset.campaign_id = {0}
+            GROUP BY label.user_id
+            ORDER BY COUNT(*) DESC;
+        """.format(int(campaign_id)))
 
-            return list(cursor)
+        return list(cursor)
 
     def days(self, campaign_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT
-                to_char(date_trunc('day', label.timestamp), 'YYYY-MM-DD')
-                AS day,
-                COUNT(*) AS count
-                FROM label
-                JOIN workset_task ON label.task_id = workset_task.task_id
-                JOIN workset ON workset_task.workset_id = workset.id
-                WHERE campaign_id = {0}
-                GROUP BY day
-                ORDER BY day DESC;
-            """.format(int(campaign_id)))
+        cursor = self.db.execute("""
+            SELECT
+            to_char(date_trunc('day', label.timestamp), 'YYYY-MM-DD')
+            AS day,
+            COUNT(*) AS count
+            FROM label
+            JOIN workset_task ON label.task_id = workset_task.task_id
+            JOIN workset ON workset_task.workset_id = workset.id
+            WHERE campaign_id = {0}
+            GROUP BY day
+            ORDER BY day DESC;
+        """.format(int(campaign_id)))
 
-            return list(cursor)
+        return list(cursor)

--- a/wikilabels/database/db.py
+++ b/wikilabels/database/db.py
@@ -31,10 +31,10 @@ class DB:
             self.pool = ThreadedConnectionPool(
                 *args, cursor_factory=RealDictCursor, **kwargs)
 
-    def execute(self, sql):
+    def execute(self, sql, *args, **kwargs):
         with self.transaction() as transactor:
             cursor = transactor.cursor()
-            cursor.execute(sql)
+            cursor.execute(sql, *args, **kwargs)
             return cursor
 
     @contextmanager

--- a/wikilabels/database/labels.py
+++ b/wikilabels/database/labels.py
@@ -23,25 +23,21 @@ class Labels(Collection):
             return result
 
     def insert(self, task_id, user_id, data):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
+        cursor = self.db.execute("""
             INSERT INTO label VALUES
               (%(task_id)s, %(user_id)s, NOW(), %(data)s)
             RETURNING *
             """, {'task_id': task_id, 'user_id': user_id, 'data': Json(data)})
-            logger.info(
-                'Insert {data} for {task} by {user}'.format(
-                    data=data,
-                    task=task_id,
-                    user=user_id))
-            for row in cursor:
-                return row
+        logger.info(
+            'Insert {data} for {task} by {user}'.format(
+                data=data,
+                task=task_id,
+                user=user_id))
+        for row in cursor:
+            return row
 
     def update(self, task_id, user_id, data):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
+        cursor = self.db.execute("""
             UPDATE label
             SET
                 data = %(data)s,
@@ -51,28 +47,26 @@ class Labels(Collection):
                 user_id = %(user_id)s
             RETURNING *
             """, {'task_id': task_id, 'user_id': user_id, 'data': Json(data)})
-            logger.info(
-                'Update {data} for {task} by {user}'.format(
-                    data=data,
-                    task=task_id,
-                    user=user_id))
-            for row in cursor:
-                return row
+        logger.info(
+            'Update {data} for {task} by {user}'.format(
+                data=data,
+                task=task_id,
+                user=user_id))
+        for row in cursor:
+            return row
 
     def clear_data(self, task_id, user_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
+        cursor = self.db.execute("""
             DELETE FROM label
             WHERE
                 task_id = %(task_id)s AND
                 user_id = %(user_id)s
             RETURNING *
             """, {'task_id': task_id, 'user_id': user_id})
-            for row in cursor:
-                logger.info('{user_id} clearing label data {label_data}'
-                            'for task {task_id}.'.format(
-                                label_data=row['data'],
-                                task_id=task_id,
-                                user_id=user_id))
-                return row
+        for row in cursor:
+            logger.info('{user_id} clearing label data {label_data}'
+                        'for task {task_id}.'.format(
+                            label_data=row['data'],
+                            task_id=task_id,
+                            user_id=user_id))
+            return row

--- a/wikilabels/database/tasks.py
+++ b/wikilabels/database/tasks.py
@@ -9,101 +9,90 @@ from .errors import NotFoundError
 class Tasks(Collection):
 
     def get(self, task_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT
-                    task.id as task_id,
-                    task.data as task_data,
-                    task.campaign_id,
-                    label.user_id,
-                    label.data as label_data,
-                    EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
-                FROM task
-                LEFT JOIN label ON task.id = label.task_id
-                WHERE task.id = %(task_id)s
-            """, {'task_id': task_id})
+        cursor = self.db.execute("""
+            SELECT
+                task.id as task_id,
+                task.data as task_data,
+                task.campaign_id,
+                label.user_id,
+                label.data as label_data,
+                EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
+            FROM task
+            LEFT JOIN label ON task.id = label.task_id
+            WHERE task.id = %(task_id)s
+        """, {'task_id': task_id})
 
-            try:
-                return self._group_task_labels(cursor)[0]
-            except IndexError:
-                raise NotFoundError("task_id={0}".format(task_id))
+        try:
+            return self._group_task_labels(cursor)[0]
+        except IndexError:
+            raise NotFoundError("task_id={0}".format(task_id))
 
     def for_workset(self, workset_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT
-                    task.id as task_id,
-                    task.data as task_data,
-                    task.campaign_id,
-                    label.user_id,
-                    label.data as label_data,
-                    EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
-                FROM workset
-                INNER JOIN workset_task ON workset_id = workset.id
-                INNER JOIN task ON workset_task.task_id = task.id
-                LEFT JOIN label ON
-                    task.id = label.task_id AND
-                    label.user_id = workset.user_id
-                WHERE workset.id = %(workset_id)s
-                ORDER BY task.id
-            """, {'workset_id': workset_id})
+        cursor = self.db.execute("""
+            SELECT
+                task.id as task_id,
+                task.data as task_data,
+                task.campaign_id,
+                label.user_id,
+                label.data as label_data,
+                EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
+            FROM workset
+            INNER JOIN workset_task ON workset_id = workset.id
+            INNER JOIN task ON workset_task.task_id = task.id
+            LEFT JOIN label ON
+                task.id = label.task_id AND
+                label.user_id = workset.user_id
+            WHERE workset.id = %(workset_id)s
+            ORDER BY task.id
+        """, {'workset_id': workset_id})
 
-            return self._group_task_labels(cursor)
+        return self._group_task_labels(cursor)
 
     def for_campaign(self, campaign_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                SELECT
-                    task.id as task_id,
-                    task.data as task_data,
-                    task.campaign_id,
-                    label.user_id,
-                    label.data as label_data,
-                    EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
-                FROM task
-                LEFT JOIN label ON task.id = label.task_id
-                WHERE task.campaign_id = %(campaign_id)s
-                ORDER BY task_id, timestamp
-            """, {'campaign_id': campaign_id})
+        cursor = self.db.execute("""
+            SELECT
+                task.id as task_id,
+                task.data as task_data,
+                task.campaign_id,
+                label.user_id,
+                label.data as label_data,
+                EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
+            FROM task
+            LEFT JOIN label ON task.id = label.task_id
+            WHERE task.campaign_id = %(campaign_id)s
+            ORDER BY task_id, timestamp
+        """, {'campaign_id': campaign_id})
 
-            return self._group_task_labels(cursor)
+        return self._group_task_labels(cursor)
 
     def for_user(self, user_id, workset_id=None, campaign_id=None):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
+        conditions = ["workset.user_id = %(user_id)s"]
+        if workset_id is not None:
+            conditions.append("workset.id = %(workset_id)s")
+        if campaign_id is not None:
+            conditions.append("workset.campaign_id = %(campaign_id)s")
+        where = "\nWHERE " + " AND ".join(conditions) + "\n"
+        cursor = self.db.execute("""
+            SELECT
+                task.id as task_id,
+                task.data as task_data,
+                task.campaign_id,
+                label.user_id,
+                label.data as label_data,
+                EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
+            FROM workset
+            INNER JOIN workset_task ON workset.id = workset_task.workset_id
+            INNER JOIN task ON workset_task.task_id = task.id
+            LEFT JOIN label ON
+                task.id = label.task_id AND
+                label.user_id = workset.user_id
+            """ + where + """
+            ORDER BY task_id, timestamp
+        """, {'user_id': user_id,
+              'workset_id': workset_id,
+              'campaign_id': campaign_id})
 
-            conditions = ["workset.user_id = %(user_id)s"]
-            if workset_id is not None:
-                conditions.append("workset.id = %(workset_id)s")
-            if campaign_id is not None:
-                conditions.append("workset.campaign_id = %(campaign_id)s")
-
-            where = "\nWHERE " + " AND ".join(conditions) + "\n"
-
-            cursor.execute("""
-                SELECT
-                    task.id as task_id,
-                    task.data as task_data,
-                    task.campaign_id,
-                    label.user_id,
-                    label.data as label_data,
-                    EXTRACT(EPOCH FROM label.timestamp) as label_timestamp
-                FROM workset
-                INNER JOIN workset_task ON workset.id = workset_task.workset_id
-                INNER JOIN task ON workset_task.task_id = task.id
-                LEFT JOIN label ON
-                    task.id = label.task_id AND
-                    label.user_id = workset.user_id
-                """ + where + """
-                ORDER BY task_id, timestamp
-            """, {'user_id': user_id,
-                  'workset_id': workset_id,
-                  'campaign_id': campaign_id})
-
-            return self._group_task_labels(cursor)
+        return self._group_task_labels(cursor)
 
     @staticmethod
     def extract_key(r):
@@ -130,30 +119,26 @@ class Tasks(Collection):
         return tasks
 
     def load(self, tasks, campaign_id):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.executemany("""
-                INSERT INTO task (campaign_id, data)
-                VALUES (%(campaign_id)s, %(data)s)
-            """, ({'campaign_id': campaign_id, 'data': Json(task)}
-                  for task in tasks))
-            return True
+        self.db.executemany("""
+            INSERT INTO task (campaign_id, data)
+            VALUES (%(campaign_id)s, %(data)s)
+        """, ({'campaign_id': campaign_id, 'data': Json(task)}
+              for task in tasks))
+        return True
 
     def remove_expired_tasks(self):
-        with self.db.transaction() as transactor:
-            cursor = transactor.cursor()
-            cursor.execute("""
-                DELETE FROM workset_task
-                USING workset_task AS wt
-                JOIN workset AS w ON
-                    w.id = wt.workset_id
-                LEFT JOIN label AS l ON
-                    l.task_id = wt.task_id AND
-                    l.user_id = w.user_id
-                WHERE
-                    workset_task.task_id = wt.task_id AND
-                    workset_task.workset_id = wt.workset_id AND
-                    l.data is NULL AND
-                    w.expires < NOW()
-                """)
-            return cursor.rowcount
+        cursor = self.db.execute("""
+            DELETE FROM workset_task
+            USING workset_task AS wt
+            JOIN workset AS w ON
+                w.id = wt.workset_id
+            LEFT JOIN label AS l ON
+                l.task_id = wt.task_id AND
+                l.user_id = w.user_id
+            WHERE
+                workset_task.task_id = wt.task_id AND
+                workset_task.workset_id = wt.workset_id AND
+                l.data is NULL AND
+                w.expires < NOW()
+        """)
+        return cursor.rowcount


### PR DESCRIPTION
Most of the wikilabels transaction are atomic and just on query
There's no need to put another contextmanager on top of them
db.execute() already has the context manager

Bug: T209604