### PR TITLE
Fix archived campaign stats

### DIFF
--- a/tests/test_stats_routes.py
+++ b/tests/test_stats_routes.py
@@ -7,5 +7,6 @@ def test_stats_wiki_campaign(client):
     # test archived campaign
     assert client.get("/stats/enwiki/7")._status_code == 200
 
+
 def test_stats(client):
     assert client.get("/stats/")._status_code == 200

--- a/tests/test_stats_routes.py
+++ b/tests/test_stats_routes.py
@@ -1,5 +1,11 @@
 from .routes_test_fixture import app  # noqa
 
 
+def test_stats_wiki_campaign(client):
+    # test active campaign
+    assert client.get("/stats/enwiki/1")._status_code == 200
+    # test archived campaign
+    assert client.get("/stats/enwiki/7")._status_code == 200
+
 def test_stats(client):
     assert client.get("/stats/")._status_code == 200

--- a/wikilabels/database/schema-testdata.sql
+++ b/wikilabels/database/schema-testdata.sql
@@ -5,6 +5,7 @@ COPY campaign (id, name, wiki, form, view, info_url, labels_per_task, tasks_per_
 4	Draft notability	enwiki	draft_notability	PageAsOfRevision		1	10	t
 5	Draft notability (raw)	enwiki	draft_notability	ParsedWikitext		1	10	t
 6	Edit Quality -- 2014 10k nlwiki	nlwiki	damaging_and_goodfaith	DiffToPrevious		1	10	t
+7	Edit Quality -- 2015 10k sample	enwiki	damaging_and_goodfaith	DiffToPrevious		1	10	f
 \.
 SELECT setval('campaign_id_seq', (SELECT max(id) FROM campaign));
 

--- a/wikilabels/wsgi/routes/stats.py
+++ b/wikilabels/wsgi/routes/stats.py
@@ -29,7 +29,7 @@ def configure(bp, config, db):
     def stats_wiki_campaign(wiki, id):
         script_tags = build_script_tags(assets.LIB_JS, config)
         style_tags = build_style_tags(assets.LIB_CSS, config)
-        campaigns = db.campaigns.for_wiki(wiki, True)
+        campaigns = db.campaigns.for_wiki(wiki, stats=True, all_=True)
         for campaign in campaigns:
             if campaign['id'] == id:
                 break


### PR DESCRIPTION
This PR allows non-active (or "archived") campaign stats to be viewable.
A route test has been supplied to verify an archived campaign page will load with status 200 now. 

https://phabricator.wikimedia.org/T223899