### PR TITLE
Minor improvements across the UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 dist: xenial
+node:
+  - 10
 services:
   - docker
 
 before_install:
     - docker-compose up -d --build
-    - npm install eslint stylelint stylelint-config-wikimedia
+    - npm install eslint@v6.1.0 stylelint stylelint-config-wikimedia
 
 before_script:
     - docker-compose exec postgres psql wikilabels -U wikilabels -f /wikilabels/wikilabels/database/schema.sql
@@ -13,6 +15,7 @@ before_script:
 script:
   - docker-compose exec wikilabels flake8 /wikilabels --ignore=E722,W504
     #  - timeout --preserve-status 8s wikilabels dev_server
+  - node --version
   - ./node_modules/.bin/eslint "wikilabels/wsgi/static/js/**/*.js"
   - ./node_modules/.bin/stylelint "wikilabels/wsgi/static/css/*.css"
   - docker-compose exec wikilabels py.test --cov=wikilabels -m "not nottravis"

--- a/wikilabels/wsgi/sessions.py
+++ b/wikilabels/wsgi/sessions.py
@@ -15,10 +15,11 @@ class BeakerSessionInterface(SessionInterface):
 
 def configure(app, config):
 
-    app.wsgi_app = SessionMiddleware(app.wsgi_app,
-                                     {'session.type': config['session']['type'],
-                                      'session.url': config['session']['url'],
-                                      'session.data_dir': config['session']['data_dir']})
+    app.wsgi_app = SessionMiddleware(
+        app.wsgi_app,
+        {'session.type': config['session']['type'],
+         'session.url': config['session']['url'],
+         'session.data_dir': config['session']['data_dir']})
     app.session_interface = BeakerSessionInterface()
 
     return app

--- a/wikilabels/wsgi/static/css/home.css
+++ b/wikilabels/wsgi/static/css/home.css
@@ -2,4 +2,5 @@
 	position: static;
 	max-width: 100em;
 	margin: 0 auto;
+	height: auto;
 }

--- a/wikilabels/wsgi/static/css/labeler.css
+++ b/wikilabels/wsgi/static/css/labeler.css
@@ -20,7 +20,6 @@ html[dir='rtl'] #wikilabels-labeler > .lead {
 #wikilabels-labeler > .wikilabels-menu {
 	text-align: center;
 	width: auto;
-	height: 20em;
 	border-left: 1px solid #c8ccd1;
 	border-right: 1px solid #c8ccd1;
 }
@@ -33,7 +32,6 @@ html[dir='rtl'] #wikilabels-labeler > .lead {
 
 #wikilabels-labeler > .menu > .campaign-list,
 #wikilabels-labeler > .wikilabels-menu > .campaign-list {
-	height: 100%;
 	overflow: auto;
 	line-height: 1;
 }

--- a/wikilabels/wsgi/static/css/workspace.css
+++ b/wikilabels/wsgi/static/css/workspace.css
@@ -1,23 +1,15 @@
 .wikilabels-workspace {
-	position: relative;
-	min-height: 5em;
-	margin-top: 1em;
-	padding: 1ex 1em;
+	position: absolute;
+	padding: 2em;
 	background: #fff;
 	box-shadow: 0 0 1em rgba( 0, 0, 0, 0.5 );
-	display: none;
-}
-
-.wikilabels-workspace.fullscreen {
-	position: absolute;
 	z-index: 3;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 2em;
-	margin-top: 0;
 	overflow: auto;
+	display: none;
 }
 
 .wikilabels-workspace > .menu,

--- a/wikilabels/wsgi/static/js/wikiLabels/Labeler.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Labeler.js
@@ -158,14 +158,6 @@
 	Campaign = function ( campaignData ) {
 		this.$element = $( '<div>' ).addClass( 'campaign' );
 
-		this.expander = new OO.ui.ToggleButtonWidget( {
-			label: '+',
-			value: false,
-			classes: [ 'expander' ]
-		} );
-		this.$element.append( this.expander.$element );
-		this.expander.on( 'change', this.handleExpanderChange.bind( this ) );
-
 		this.$name = $( '<div>' ).addClass( 'name' );
 		this.$element.append( this.$name );
 		if ( campaignData.info_url ) {
@@ -189,9 +181,6 @@
 		this.worksetActivated = $.Callbacks();
 
 		this.load( campaignData );
-	};
-	Campaign.prototype.handleExpanderChange = function ( expanded ) {
-		this.expand( expanded );
 	};
 	Campaign.prototype.handleNewButtonClick = function () {
 		this.assignNewWorkset();
@@ -236,20 +225,6 @@
 			.fail( function ( doc ) {
 				OO.ui.alert( WL.i18n( 'Could not load workset list: $1', [ JSON.stringify( doc ) ] ) );
 			} );
-	};
-	Campaign.prototype.expand = function ( expanded ) {
-		if ( expanded === undefined ) {
-			return this.$element.hasClass( 'expanded' );
-		} else if ( expanded ) {
-			this.$element.addClass( 'expanded' );
-			this.expander.setLabel( '-' );
-			this.expanded.fire( expanded );
-			return this;
-		} else {
-			this.$element.removeClass( 'expanded' );
-			this.expander.setLabel( '+' );
-			return this;
-		}
 	};
 
 	/**

--- a/wikilabels/wsgi/static/js/wikiLabels/Workspace.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Workspace.js
@@ -16,7 +16,7 @@
 		this.$menu = $( '<div>' ).addClass( 'wikilabels-menu' );
 		this.$element.append( this.$menu );
 		this.closeButton = new OO.ui.ButtonWidget( {
-			label: "X",
+			label: 'X',
 			classes: [ 'close' ]
 		} );
 		this.$menu.append( this.closeButton.$element );
@@ -50,13 +50,13 @@
 	};
 	Workspace.prototype.close = function () {
 		this.clear();
-		this.visible(false)
+		this.visible( false );
 	};
 	Workspace.prototype.loadWorkset = function ( campaignId, worksetId ) {
 		var taskList, form, view,
 			query = WL.server.getWorkset( campaignId, worksetId );
 		this.clear();
-		this.visible(true)
+		this.visible( true );
 		query.done( function ( doc ) {
 			var formQuery;
 
@@ -195,14 +195,14 @@
 	};
 	Workspace.prototype.visible = function ( visible ) {
 		if ( visible === undefined ) {
-			return self.$element.visible()
+			return self.$element.visible();
 		} else if ( visible ) {
 			$( 'body' ).append( this.$element );
-			this.$element.show()
+			this.$element.show();
 		} else {
-			this.$element.hide()
+			this.$element.hide();
 		}
-	}
+	};
 
 	TaskList = function ( taskListData ) {
 		this.$element = $( '<div>' ).addClass( 'task-list' );

--- a/wikilabels/wsgi/static/js/wikiLabels/Workspace.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Workspace.js
@@ -13,16 +13,14 @@
 		this.form = null;
 		this.view = null;
 
-		this.$parent = $element.parent();
-
 		this.$menu = $( '<div>' ).addClass( 'wikilabels-menu' );
 		this.$element.append( this.$menu );
-		this.fullscreenToggle = new OO.ui.ToggleButtonWidget( {
-			label: WL.i18n( 'fullscreen' ),
-			classes: [ 'fullscreen' ]
+		this.closeButton = new OO.ui.ButtonWidget( {
+			label: "X",
+			classes: [ 'close' ]
 		} );
-		this.$menu.append( this.fullscreenToggle.$element );
-		this.fullscreenToggle.on( 'change', this.handleFullscreenChange.bind( this ) );
+		this.$menu.append( this.closeButton.$element );
+		this.closeButton.on( 'click', this.handleClose.bind( this ) );
 
 		this.$container = $( '<div>' ).addClass( 'container' );
 		this.$element.append( this.$container );
@@ -44,18 +42,21 @@
 			this.form.show();
 		}
 	};
-	Workspace.prototype.handleFullscreenChange = function () {
-		this.fullscreenToggle.setLabel( this.fullscreenToggle.getValue() ? WL.i18n( 'exit fullscreen' ) : WL.i18n( 'fullscreen' ) );
-		this.fullscreen( this.fullscreenToggle.getValue() );
+	Workspace.prototype.handleClose = function () {
+		this.close();
 	};
 	Workspace.prototype.handleNewWorksetRequested = function () {
 		this.newWorksetRequested.fire();
+	};
+	Workspace.prototype.close = function () {
+		this.clear();
+		this.visible(false)
 	};
 	Workspace.prototype.loadWorkset = function ( campaignId, worksetId ) {
 		var taskList, form, view,
 			query = WL.server.getWorkset( campaignId, worksetId );
 		this.clear();
-		this.$element.show();
+		this.visible(true)
 		query.done( function ( doc ) {
 			var formQuery;
 
@@ -112,8 +113,6 @@
 		this.view = view;
 		this.$container.append( view.$element );
 		this.view.newWorksetRequested.add( this.handleNewWorksetRequested.bind( this ) );
-
-		this.fullscreenToggle.setDisabled( false );
 
 		firstTask = this.taskList.selectByIndex( 0 );
 		this.view.show( firstTask.id );
@@ -193,8 +192,17 @@
 	};
 	Workspace.prototype.clear = function () {
 		this.$container.empty();
-		this.fullscreenToggle.setDisabled( true );
 	};
+	Workspace.prototype.visible = function ( visible ) {
+		if ( visible === undefined ) {
+			return self.$element.visible()
+		} else if ( visible ) {
+			$( 'body' ).append( this.$element );
+			this.$element.show()
+		} else {
+			this.$element.hide()
+		}
+	}
 
 	TaskList = function ( taskListData ) {
 		this.$element = $( '<div>' ).addClass( 'task-list' );

--- a/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
@@ -36,8 +36,8 @@
 	MediaWiki.prototype.urlToDiff = function ( revId ) {
 		return '//' + this.host + this.script + '?diff=' + revId;
 	};
-	MediaWiki.prototype.baseTag = function ( revId ) {
-		return $("<base>").attr('href', '//' + this.host)
+	MediaWiki.prototype.baseTag = function () {
+		return $( '<base>' ).attr( 'href', '//' + this.host );
 	};
 
 	WL.mediawiki = new MediaWiki();

--- a/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
@@ -36,6 +36,9 @@
 	MediaWiki.prototype.urlToDiff = function ( revId ) {
 		return '//' + this.host + this.script + '?diff=' + revId;
 	};
+	MediaWiki.prototype.baseTag = function ( revId ) {
+		return $("<base>").attr('href', '//' + this.host)
+	};
 
 	WL.mediawiki = new MediaWiki();
 }( jQuery, wikiLabels ) );

--- a/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
@@ -1,5 +1,4 @@
 ( function ( $, WL ) {
-
 	var MediaWiki = function () {};
 	MediaWiki.prototype.initialize = function ( host ) {
 		var deferred = $.Deferred();
@@ -38,6 +37,12 @@
 	};
 	MediaWiki.prototype.reBaseUrl = function ( relativeUrl ) {
 		return String( new URL( relativeUrl, 'https://' + this.host ) );
+	};
+	MediaWiki.prototype.reBaseRelativeAnchors = function ( i, node ) {
+		var href = node.getAttribute( 'href' );
+		if ( !WL.ABS_URL_PREFIX.test( href ) ) {
+			node.setAttribute( 'href', WL.mediawiki.reBaseUrl( href ) );
+		}
 	};
 
 	WL.mediawiki = new MediaWiki();

--- a/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/mediawiki.js
@@ -36,8 +36,8 @@
 	MediaWiki.prototype.urlToDiff = function ( revId ) {
 		return '//' + this.host + this.script + '?diff=' + revId;
 	};
-	MediaWiki.prototype.baseTag = function () {
-		return $( '<base>' ).attr( 'href', '//' + this.host );
+	MediaWiki.prototype.reBaseUrl = function ( relativeUrl ) {
+		return String( new URL( relativeUrl, 'https://' + this.host ) );
 	};
 
 	WL.mediawiki = new MediaWiki();

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -283,7 +283,7 @@
 		this.$element.addClass( WL.config.prefix + 'page-as-of-revision' )
 			.addClass( 'display-page-html' );
 		this.$base = WL.mediawiki.baseTag();
-		this.$element.append(this.$base);
+		this.$element.append( this.$base );
 	};
 	OO.inheritClass( PageAsOfRevision, View );
 	PageAsOfRevision.prototype.present = function ( taskInfo ) {

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -1,7 +1,8 @@
 ( function ( $, WL ) {
 	var View, DiffToPrevious, MultiDiffToPrevious, PageAsOfRevision,
 		PrintablePageAsOfRevision, ParsedWikitext,
-		WorksetCompleted, RenderedHTML, UnsourcedStatement;
+		WorksetCompleted, RenderedHTML, UnsourcedStatement,
+		ABS_URL_PREFIX = /^(?:https?:)?\/\//i;
 
 	View = function ( taskListData ) {
 		this.$element = $( '<div>' ).addClass( WL.config.prefix + 'view' );
@@ -282,8 +283,8 @@
 		PageAsOfRevision.super.call( this, taskListData );
 		this.$element.addClass( WL.config.prefix + 'page-as-of-revision' )
 			.addClass( 'display-page-html' );
-		this.$base = WL.mediawiki.baseTag();
-		this.$element.append( this.$base );
+		this.$article = $( '<div>' ).addClass( 'article' );
+		this.$element.append( this.$article );
 	};
 	OO.inheritClass( PageAsOfRevision, View );
 	PageAsOfRevision.prototype.present = function ( taskInfo ) {
@@ -304,21 +305,28 @@
 				}.bind( this ) )
 				.fail( function ( doc ) {
 					var error = $( '<pre>' ).addClass( 'error' );
-					this.$base.html( error.text( JSON.stringify( doc, null, 2 ) ) );
+					this.$article.html( error.text( JSON.stringify( doc, null, 2 ) ) );
 				}.bind( this ) );
 		}
 	};
 	PageAsOfRevision.prototype.presentPage = function ( title, html ) {
-		this.$base.html( '' );
-		this.$base.append(
+		this.$article.html( '' );
+		this.$article.append(
 			$( '<h1>' ).text( title )
 				.attr( 'id', 'firstHeading' )
 				.addClass( 'firstHeading' )
 		);
-		this.$base.append(
+		this.$article.append(
 			$( '<div>' ).html( html )
 				.addClass( 'mw-body-content' )
 				.attr( 'id', 'bodyContent' )
+		).find( 'a' ).each(
+			function ( i, node ) {
+				var href = node.getAttribute( 'href' );
+				if ( !ABS_URL_PREFIX.test( href ) ) {
+					node.setAttribute( 'href', WL.mediawiki.reBaseUrl( href ) );
+				}
+			}
 		);
 	};
 

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -282,6 +282,8 @@
 		PageAsOfRevision.super.call( this, taskListData );
 		this.$element.addClass( WL.config.prefix + 'page-as-of-revision' )
 			.addClass( 'display-page-html' );
+		this.$base = WL.mediawiki.baseTag();
+		this.$element.append(this.$base);
 	};
 	OO.inheritClass( PageAsOfRevision, View );
 	PageAsOfRevision.prototype.present = function ( taskInfo ) {
@@ -302,18 +304,18 @@
 				}.bind( this ) )
 				.fail( function ( doc ) {
 					var error = $( '<pre>' ).addClass( 'error' );
-					this.$element.html( error.text( JSON.stringify( doc, null, 2 ) ) );
+					this.$base.html( error.text( JSON.stringify( doc, null, 2 ) ) );
 				}.bind( this ) );
 		}
 	};
 	PageAsOfRevision.prototype.presentPage = function ( title, html ) {
-		this.$element.html( '' );
-		this.$element.append(
+		this.$base.html( '' );
+		this.$base.append(
 			$( '<h1>' ).text( title )
 				.attr( 'id', 'firstHeading' )
 				.addClass( 'firstHeading' )
 		);
-		this.$element.append(
+		this.$base.append(
 			$( '<div>' ).html( html )
 				.addClass( 'mw-body-content' )
 				.attr( 'id', 'bodyContent' )

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -1,8 +1,7 @@
 ( function ( $, WL ) {
 	var View, DiffToPrevious, MultiDiffToPrevious, PageAsOfRevision,
 		PrintablePageAsOfRevision, ParsedWikitext,
-		WorksetCompleted, RenderedHTML, UnsourcedStatement,
-		ABS_URL_PREFIX = /^(?:https?:)?\/\//i;
+		WorksetCompleted, RenderedHTML, UnsourcedStatement;
 
 	View = function ( taskListData ) {
 		this.$element = $( '<div>' ).addClass( WL.config.prefix + 'view' );
@@ -125,6 +124,7 @@
 		this.$element.append( description );
 
 		this.$element.append( comment.html( diff.comment ) );
+		comment.find( 'a' ).each( WL.mediawiki.reBaseRelativeAnchors );
 
 		if ( diff.tableRows ) {
 			diffTable.append(
@@ -260,6 +260,7 @@
 			this.$element.append( description );
 
 			this.$element.append( comment.html( diff.comment ) );
+			comment.find( 'a' ).each( WL.mediawiki.reBaseRelativeAnchors );
 
 			if ( diff.tableRows ) {
 				diffTable.append(
@@ -320,14 +321,7 @@
 			$( '<div>' ).html( html )
 				.addClass( 'mw-body-content' )
 				.attr( 'id', 'bodyContent' )
-		).find( 'a' ).each(
-			function ( i, node ) {
-				var href = node.getAttribute( 'href' );
-				if ( !ABS_URL_PREFIX.test( href ) ) {
-					node.setAttribute( 'href', WL.mediawiki.reBaseUrl( href ) );
-				}
-			}
-		);
+		).find( 'a' ).each( WL.mediawiki.reBaseRelativeAnchors );
 	};
 
 	PrintablePageAsOfRevision = function ( taskListData ) {
@@ -370,6 +364,8 @@
 	};
 	ParsedWikitext.prototype.presentHTML = function ( html ) {
 		this.$element.html( html );
+		this.$element.find( 'a' ).each( WL.mediawiki.reBaseRelativeAnchors );
+
 	};
 
 	RenderedHTML = function ( taskListData ) {

--- a/wikilabels/wsgi/static/js/wikiLabels/wikiLabels.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/wikiLabels.js
@@ -6,6 +6,7 @@
 		config: {
 			serverRoot: '',
 			prefix: 'wikilabels-'
-		}
+		},
+		ABS_URL_PREFIX: /^(?:https?:)?\/\//i
 	};
 }() );

--- a/wikilabels/wsgi/templates/ui_wiki.html
+++ b/wikilabels/wsgi/templates/ui_wiki.html
@@ -24,11 +24,13 @@
     <style type="text/css">
     html {
       background: #eaecf0;
+      height: auto;
     }
     body {
       margin: 0px auto;
-      padding: 1em 2em;
+      padding: 0em 2em;
       background: #fff;
+      height: auto;
     }
     @media ( min-width: 992px ) {
         .content-box {


### PR DESCRIPTION
* List of campaigns and worksets in labeler can take up full height of page.
* Labeler is now always fullscreen when present.
* Heights are set correctly in labeling interface to avoid unnecessary
  scrolling.
* Relative links that appear inside of rendered wiki pages now work
  correctly
* Removes non-functional [+] buttons from campaign list